### PR TITLE
Save connection feature - lukemurray/data-atom#18

### DIFF
--- a/lib/data-managers/db-factory.js
+++ b/lib/data-managers/db-factory.js
@@ -23,6 +23,14 @@ class DbFactory {
     });
   }
 
+  // TODO: Do not save same connection multiple times
+  saveConnection(connection, callback) {
+    this.readFile((connections) => {
+      connections.push(connection);
+      this.writeFile(connections, callback);
+    });
+  }
+
   readFile(callback) {
     fs.exists(this.file(), (exists) => {
       if (exists) {

--- a/lib/new-connection-dialog.js
+++ b/lib/new-connection-dialog.js
@@ -106,6 +106,23 @@ class NewConnectionDialog {
     group = document.createElement('div');
     group.classList.add('form-group');
     panelBody.appendChild(group);
+    label = document.createElement('label');
+    label.classList.add('col-md-2');
+    label.classList.add('control-label');
+    label.innerText = 'Name';
+    group.appendChild(label);
+    div = document.createElement('div');
+    div.classList.add('col-md-10');
+    group.appendChild(div);
+    this.name = document.createElement('atom-text-editor');
+    this.name.setAttribute('mini', '');
+    //this.name.setAttribute('tabindex', '');
+    this.name.setAttribute('placeholder-text', 'connection-name');
+    div.appendChild(this.name);
+
+    group = document.createElement('div');
+    group.classList.add('form-group');
+    panelBody.appendChild(group);
     var label = document.createElement('label');
     label.classList.add('col-md-2');
     label.classList.add('control-label');
@@ -236,6 +253,13 @@ class NewConnectionDialog {
     div.appendChild(btn);
     btn.addEventListener('click', () => this.connect());
 
+    this.saveAndConnectBtn = document.createElement('button');
+    this.saveAndConnectBtn.setAttribute('tabindex', '10');
+    this.saveAndConnectBtn.className = 'btn btn-default btn-padding-left';
+    this.saveAndConnectBtn.innerText = 'Save and Connect';
+    div.appendChild(this.saveAndConnectBtn);
+    this.saveAndConnectBtn.addEventListener('click', () => this.connectAndSave());
+
     btn = document.createElement('button');
     btn.setAttribute('tabindex', '11');
     btn.className = 'btn btn-default btn-padding-left';
@@ -335,9 +359,12 @@ class NewConnectionDialog {
     for (var i = 0; i < this.connections.childNodes.length; i++) {
       var n = this.connections.childNodes[i];
       if (n.selected) {
+        this.name.getModel().setText(n.innerText);
         this.url.getModel().setText(n.value);
         this.url.focus();
+        this.saveAndConnectBtn.disabled = (n.value !== '')
         if(n.value === '') {
+          this.name.getModel().setText('');
           this.dbOptions.getModel().setText('');
           this.dbServer.getModel().setText('');
           this.dbPort.getModel().setText('');
@@ -360,6 +387,29 @@ class NewConnectionDialog {
         return;
       }
     }
+  }
+
+  // Called when the user clicks the save and connect button.
+  connectAndSave() {
+    var connection = {
+      name: this.name.getModel().getText() !== '' ? this.name.getModel().getText() : this.dbName.getModel().getText(),
+      protocol: this.urlProtocol,
+      user: this.dbUser.getModel().getText(),
+      password: this.dbPassword.getModel().getText(),
+      server: this.dbServer.getModel().getText(),
+      database: this.dbName.getModel().getText(),
+      options: this.dbOptions.getModel().getText()
+    };
+    if(this.dbPort.getModel().getText() !== '')
+      connection.port = this.dbPort.getModel().getText();
+    DbFactory.saveConnection(connection, () => {
+      var opt = document.createElement('option');
+      opt.innerText = connection.name;
+      opt.setAttribute('value', this.url.getModel().getText());
+      this.connections.appendChild(opt);
+      this.onConnectClicked(this.url.getModel().getText());
+      this.close();
+    });
   }
 
   // Called when the user clicks the connect button. Triggers a callback for the controller to


### PR DESCRIPTION
lukemurray/data-atom#18

@lukemurray I disable the save button when selecting to load a pre-existing saved connection to prevent saving duplicate connections. I would like to build a UI that looks similar to the new connection dialog for editing connections rather than having the user have to manually edit the data-atom-connections file. Would suggest opening a new issue/feature just to log comments and have some tracking as well as allowing potential users to be able to see what is currently on the table for development/improvement.