### PR TITLE
Autocompletion support for tables and cols

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -112,7 +112,6 @@ export default class DataAtomController {
     else {
       this.mainView.setState('0', [], '', currentViewState.useEditorAsQuery);
     }
-
     this.mainView.show();
     currentViewState.isMainViewShowing = true;
     // if they toggle the details closed but have the results open, we don't want to open it again on active tab changes
@@ -237,11 +236,27 @@ export default class DataAtomController {
 
           this.detailsView.setDbManager(dbManager);
         }
+        this.setupAutocomplete(currentState.database, dbManager);
         if (thenDo)
           thenDo();
       });
     }
     this.newConnectionDialog.show();
+  }
+
+  setupAutocomplete(database, dbManager) {
+    var editor = atom.workspace.getActiveTextEditor();
+    dbManager.getTableNames(database, (tables) => {
+      editor.dataAtomTables = tables;
+
+      dbManager.getTableDetails(database, tables, (details) => {
+        var columns = {};
+        details.forEach(function(detail) {
+          columns[detail.name] = detail.udt || detail.type;
+        });
+        editor.dataAtomColumns = columns;
+      });
+    });
   }
 
   newQuery() {

--- a/lib/data-atom.js
+++ b/lib/data-atom.js
@@ -2,8 +2,13 @@
 
 import DataAtomController from './data-atom-controller';
 import StatusBarManager from './status-bar-manager';
+import SQLMetaProvider from './sql-meta-provider';
 
 export default {
+  provide: function() {
+    return SQLMetaProvider;
+  },
+
   config: {
     showDetailsViewOnRightSide: {
       type: 'boolean',

--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -132,8 +132,10 @@ export default class PostgresManager extends DataManager {
     );
   }
 
-  getTableDetails(database, table, onSuccess) {
-    this.execute(database, 'select column_name, data_type, udt_name, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name = \'' + table + '\';',
+  getTableDetails(database, tables, onSuccess) {
+    var sqlTables = "('" + tables.join("','") +  "')";
+
+    this.execute(database, 'select column_name, data_type, udt_name, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name IN ' + sqlTables + ';',
       results => {
         var columns = [];
         for(var i = 0; i < results[0].rows.length; i++) {

--- a/lib/data-managers/sqlserver-manager.js
+++ b/lib/data-managers/sqlserver-manager.js
@@ -132,8 +132,10 @@ export default class SqlServerManager extends DataManager {
     );
   }
 
-  getTableDetails(database, table, onSuccess) {
-    this.execute(database, 'select column_name, data_type, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name = \'' + table + '\';',
+  getTableDetails(database, tables, onSuccess) {
+    var sqlTables = "('" + tables.join("','") +  "')";
+
+    this.execute(database, 'select column_name, data_type, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name IN ' + sqlTables + ';',
       results => {
         var columns = [];
         for(var i = 0; i < results[0].rows.length; i++) {

--- a/lib/sql-meta-provider.js
+++ b/lib/sql-meta-provider.js
@@ -1,0 +1,33 @@
+"use babel";
+var SQLMetaProvider = {
+  selector: '*',
+
+  getTableNames(editor, prefix) {
+    let tables = editor.dataAtomTables || [];
+    let valid = tables.filter((x) => x.startsWith(prefix));
+    return valid.map((table) => {
+      return {
+        text: table,
+        rightLabel: 'Table'
+      };
+    });
+  },
+
+  getColumnNames(editor, prefix) {
+    let columns = Object.keys(editor.dataAtomColumns || {});
+    let valid = columns.filter((x) => x.startsWith(prefix));
+    return valid.map((column) => {
+      return {
+        text: column,
+        rightLabel: 'Column',
+        leftLabel: editor.dataAtomColumns[column]
+      }
+    });
+  },
+
+  getSuggestions: function({editor, bufferPosition, scopeDescriptor, prefix, activatedManually}) {
+    return this.getTableNames(editor, prefix).concat(this.getColumnNames(editor, prefix));
+  }
+}
+
+export default SQLMetaProvider;

--- a/lib/views/data-details-view.js
+++ b/lib/views/data-details-view.js
@@ -85,7 +85,7 @@ export default class DataDetailsView {
   buildTableDetails(element, table, database) {
     var columnList = document.createElement('ol');
     columnList.className = 'column-list list-tree';
-    this.DbManager.getTableDetails(database, table, (columns) => {
+    this.DbManager.getTableDetails(database, [table], (columns) => {
       for(var i = 0; i < columns.length; i++) {
         var col = document.createElement('li');
         col.className = 'col list-nested-item';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
       }
     }
   },
+  "providedServices": {
+    "autocomplete.provider": {
+      "versions": {
+        "2.0.0": "provide"
+      }
+    }
+  },
   "dependencies": {
     "mssql": "^2.2.1",
     "pg": "git+https://github.com/lukemurray/node-postgres#master",

--- a/spec/sql-meta-provider-spec.js
+++ b/spec/sql-meta-provider-spec.js
@@ -1,0 +1,33 @@
+'use babel';
+
+import SQLMetaProvider from '../lib/sql-meta-provider';
+
+describe('SQLMetaProvider', () => {
+  describe('Get table names', () => {
+    it('filters by prefix', () => {
+      let editor = {
+        dataAtomTables: ['test_table', 'other_table', 'test_table_2']
+      }
+      let tables = SQLMetaProvider.getTableNames(editor, 'test');
+
+      expect(tables).not.toContain({text: 'other_table', rightLabel: 'Table'});
+      expect(tables).toContain({text: 'test_table', rightLabel: 'Table'});
+      expect(tables).toContain({text: 'test_table_2', rightLabel: 'Table'});
+      expect(tables.length).toEqual(2);
+    });
+  });
+
+  describe('Get column names', () => {
+    it('filters by prefix', () => {
+      let editor = {
+        dataAtomColumns: {
+          'test_col': 'varchar',
+          'other_col': 'bool'
+        }
+      };
+      let cols = SQLMetaProvider.getColumnNames(editor, 'test');
+      expect(cols).toContain({text: 'test_col', rightLabel: 'Column', leftLabel: 'varchar'});
+      expect(cols.length).toEqual(1);
+    });
+  });
+})


### PR DESCRIPTION
Hi @lukemurray 

Thanks for the addon, exactly what I've been looking for!

## What this does

Adds auto-completions for table and column names in the active editor when a connection is established. 

## Notes:

* The auto-completions are fetched when the connection made and attached to the currently active `editor`, open to suggestions on a better way of managing this.
* Does not support 2 columns with same name but different data types in different tables, it will take the data type of the last one found.
* The SQLServer integration hasn't been tested, I don't have access to a database. Would you mind taking it for a quick spin?

Let me know if you'd like any modifications