### PR TITLE
fix(lukemurray/data-atom#38): Cannot read property 'execute' of undefined

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -231,16 +231,15 @@ export default class DataAtomController {
         dbManager.getDatabaseNames(names => this.mainView.setState(dbManager.getConnectionName(), names, currentState.database, currentState.useEditorAsQuery));
       }
       else {
-        currentState.database = dbManager.defaultDatabase;
-
         this.connectionList[dbManager.getConnectionName()] = dbManager;
 
-        currentState.connectionName = dbManager.getConnectionName();
         this.mainView.addConnection(dbManager.getConnectionName());
         dbManager.getDatabaseNames(names => this.mainView.setState(dbManager.getConnectionName(), names, currentState.database, currentState.useEditorAsQuery));
 
         this.detailsView.setDbManager(dbManager);
       }
+      currentState.database = dbManager.defaultDatabase;
+      currentState.connectionName = dbManager.getConnectionName();
       this.setupAutocomplete(currentState.database, dbManager);
       if (thenDo)
         thenDo();


### PR DESCRIPTION
Moved the database and connection name assignments out of the else statement, so that they're assigned for both cases (db exists and not).