### PR TITLE
Adds initial support for MySQL

### DIFF
--- a/lib/data-managers/db-factory.js
+++ b/lib/data-managers/db-factory.js
@@ -8,7 +8,8 @@ class DbFactory {
   getSupportedDatabases() {
     return [
       {name: 'PostgreSQL', prefix: 'postgresql', port: 5432},
-      {name: 'MS SQL Server', prefix: 'sqlserver', port: 1433}
+      {name: 'MS SQL Server', prefix: 'sqlserver', port: 1433},
+      {name: 'MySQL', prefix: 'mysql', port: 3306}
     ];
   }
 
@@ -57,6 +58,10 @@ class DbFactory {
   createDataManagerForUrl(url) {
     var protocol = URL.parse(url).protocol.replace(':', '');
     switch (protocol) {
+      case 'mysql': {
+        var MysqlManager = require('./mysql-manager');
+        return new MysqlManager(url);
+      }
       case 'postgresql': {
         var PostgresManager = require('./postgres-manager');
         return new PostgresManager(url);

--- a/lib/data-managers/mysql-manager.js
+++ b/lib/data-managers/mysql-manager.js
@@ -1,0 +1,158 @@
+"use babel";
+
+import mysql from 'mysql';
+import DataManager from './data-manager';
+
+export default class MysqlManager extends DataManager {
+  constructor(url) {
+    super(url);
+    this.pool = null;
+  }
+
+  destroy() {
+    this.connection.end();
+  }
+
+  execute(database, query, onSuccess, onError, onQueryToken) {
+    var url = database !== '' ? this.getUrlWithDb(database) : this.getUrl();
+    if (!this.pool) {
+      let config = {
+        host: this.config.server,
+        user: this.config.user,
+        password: this.config.password,
+        port: this.config.port,
+        multipleStatements: true
+      };
+
+      if (database) {
+        config.database = database;
+      }
+      this.pool = mysql.createPool(config);
+    }
+
+    console.log(url);
+
+    this.pool.getConnection((err, connection) => {
+      if (err && onError) {
+        onError(err);
+        return;
+      }
+
+      if (connection) {
+        connection.query( query, (err, results, fields) => {
+          if (err && onError) {
+            onError(err);
+            return;
+          }
+
+          if (!fields || (fields.length && fields[0].constructor.name === 'FieldPacket')) {
+            onSuccess(this.translateResults([results], [fields]));
+          } else {
+            onSuccess(this.translateResults(results, fields));
+          }
+          connection.release();
+        });
+      }
+    });
+  }
+
+  // conver the results into what we expect so the UI doens't have to handle all different result types
+  translateResults(results, fieldResults) {
+    var translatedResults = [];
+
+    for (var i = 0; i < results.length; i++) {
+      let rows = results[i];
+
+      if (this.isOkPacket(rows)) {
+        let message = rows.message || `${rows.affectedRows} rows affected. ${rows.changedRows} changed.`;
+
+        translatedResults.push({
+          message: message,
+          fields: [],
+          rowCount: rows.affectedRows,
+          rows: []
+        });
+      } else {
+        let fields = fieldResults[i];
+        let fieldData = fields.map(function(f) { return {name: f.name};});
+        translatedResults.push({
+          command: 'SELECT',
+          fields: fieldData,
+          rowCount: rows.length,
+          rows: this.prepareRowData(rows, fields)
+        });
+      }
+    }
+    return translatedResults;
+  }
+
+  isOkPacket(row) {
+    return row && row.constructor && row.constructor.name === 'OkPacket';
+  }
+
+  prepareRowData(rows, fields) {
+    return rows.map(function(r) {
+      return fields.map(function(f){
+        return "" + r[f.name]
+      });
+    });
+  }
+
+  checkSuperUser(callback) {
+    callback();
+  }
+
+  getDatabaseNames(onNames) {
+    onNames([]);
+    let query = `show databases`;
+
+    let connection = mysql.createConnection({
+      host: this.config.server,
+      user: this.config.user,
+      password: this.config.password,
+      port: this.config.port
+    });
+
+    if (!connection) {
+      console.error(err);
+      return;
+    }
+
+    connection.query('SHOW DATABASES', (err, rows) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+
+      onNames(rows.map(function(x) { return x.Database}));
+      connection.destroy();
+    });
+  }
+
+  getTableNames(database, onNames) {
+    let query = `select table_name from information_schema.tables WHERE table_schema='${database}'`;
+    this.execute(database, query, results => {
+      if (results && results.length && results[0].rows && results[0].rows.length) {
+        onNames(results[0].rows.map(function(r) { return r[0]; }));
+      } else {
+        onNames([]);
+      }
+    });
+  }
+
+  getTableDetails(database, tables, onSuccess) {
+    let query = `select column_name,data_type, character_maximum_length from information_schema.columns WHERE table_schema='${database}'`;
+    this.execute(database, query, results => {
+      let columns = [];
+      for(var i = 0; i < results[0].rows.length; i++) {
+        columns.push({
+          name: results[0].rows[i][0],
+          type: results[0].rows[i][1],
+          udt: results[0].rows[i][1],
+          size: results[0].rows[i][2]
+        });
+      }
+      onSuccess(columns);
+    });
+  }
+}

--- a/lib/data-managers/mysql-manager.js
+++ b/lib/data-managers/mysql-manager.js
@@ -141,7 +141,12 @@ export default class MysqlManager extends DataManager {
   }
 
   getTableDetails(database, tables, onSuccess) {
-    let query = `select column_name,data_type, character_maximum_length from information_schema.columns WHERE table_schema='${database}'`;
+    var sqlTables = "('" + tables.join("','") +  "')";
+
+    let query = `SELECT column_name,data_type, character_maximum_length
+                  FROM information_schema.columns
+                  WHERE table_schema='${database}'
+                    AND table_name IN ${sqlTables}`;
     this.execute(database, query, results => {
       let columns = [];
       for(var i = 0; i < results[0].rows.length; i++) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "mysql": "^2.9.0",
     "mssql": "^2.2.1",
     "pg": "git+https://github.com/lukemurray/node-postgres#master",
     "underscore.string": "^2.3.3",


### PR DESCRIPTION
Issue #37

Supported:
* Create and store connections
* Database names and table details
* Multiple queries

Not yet available:
* Cancel queries in progress
* Toggling connections in single file

This is a work in progress but I think it might be worthy of a merge.
It is standalone so could be billed as 'experimental support', it would be great to get more people testing it.