### PR TITLE
Add functionality to execute current cursor query

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -86,7 +86,8 @@ export default class DataAtomController {
         isDetailsViewShowing: false,
         connectionName: null,
         database: null,
-        useEditorAsQuery: (/p?sql$/).test(editor.getTitle()) || editor.getGrammar().name == 'SQL' ? true : false
+        useEditorAsQuery: (/p?sql$/).test(editor.getTitle()) || editor.getGrammar().name == 'SQL' ? true : false,
+        useQueryAtCursor: atom.config.get('data-atom.useQueryAtCursor')
       };
     }
 
@@ -302,7 +303,7 @@ export default class DataAtomController {
 
     var currentViewState = this.getOrCreateCurrentResultView();
     // the toggle in the main view tells us where to get the query from
-    var query = this.mainView.getQuery(currentViewState.useEditorAsQuery);
+    var query = this.mainView.getQuery(currentViewState.useEditorAsQuery, currentViewState.useQueryAtCursor);
     if (!currentViewState || !currentViewState.connectionName) {
       this.createNewConnection(() => {
         this.actuallyExecute(currentViewState, query);

--- a/lib/data-atom.js
+++ b/lib/data-atom.js
@@ -17,6 +17,11 @@ export default {
     openDetailsViewWhenOpeningMainResultsView: {
       type: 'boolean',
       default: false,
+    },
+    useQueryAtCursor: {
+      type: 'boolean',
+      default: false,
+      description: 'If checked, only execute the query at the active cursor; otherwise, use the entire buffer\'s text.'
     }
   },
 

--- a/lib/views/data-atom-view.js
+++ b/lib/views/data-atom-view.js
@@ -59,9 +59,35 @@ export default class DataAtomView {
     this.queryEditor.focus();
   }
 
-  getQuery(useEditorAsQuery) {
+  getQuery(useEditorAsQuery, useQueryAtCursor) {
     var editor = atom.workspace.getActiveTextEditor();
-    return useEditorAsQuery ? (editor.getSelectedText() ? editor.getSelectedText() : editor.getText()) : this.queryEditor.getModel().getText();
+    if (useEditorAsQuery) {
+      var selectedText = editor.getSelectedText();
+      if (useQueryAtCursor && !selectedText) {
+        selectedText = this.getQueryAtCursor(editor, selectedText);
+      }
+      return selectedText ? selectedText : editor.getText();
+    } else {
+      return this.queryEditor.getModel().getText();
+    }
+  }
+
+  getQueryAtCursor(editor, selectedText) {
+    var queryEndRegex = /^.*\;$/;
+    var currentCursorRow = editor.getCursorBufferPosition().row;
+    var selectionRange = [[0], [0]];
+    editor.scanInBufferRange(queryEndRegex, [[currentCursorRow], [editor.getLastBufferRow() + 1]],
+      function(endMatch) {
+        selectionRange[1] = [endMatch.range.start.row + 1];
+        endMatch.stop();
+    });
+    editor.backwardsScanInBufferRange(queryEndRegex, [[0], [currentCursorRow]],
+      function(startMatch) {
+        selectionRange[0] = [startMatch.range.start.row + 1];
+        startMatch.stop();
+    });
+    editor.setSelectedBufferRange(selectionRange);
+    return editor.getSelectedText();
   }
 
   getSelectedDatabase() {

--- a/spec/data-atom-view-spec.js
+++ b/spec/data-atom-view-spec.js
@@ -46,7 +46,7 @@ describe("DataAtomView", () => {
     });
   });
 
-  describe('When toggling query source', () => {
+  describe('when toggling query source', () => {
     var view;
     beforeEach(() => {
       view = new DataAtomView();
@@ -74,6 +74,22 @@ describe("DataAtomView", () => {
       view.useEditorAsQuerySource(false);
       view.queryEditor.getModel().setText('test2');
       expect(view.getQuery()).toEqual('test2');
+    });
+  });
+
+  describe('when "useQueryAtCursor" option is "true"', () => {
+    var view;
+    beforeEach(() => {
+      view = new DataAtomView();
+      waitsForPromise(() => {
+        return atom.workspace.open('test.sql');
+      });
+    });
+
+    it('it only gets the query at the cursor', () => {
+      var editor = atom.workspace.getActiveTextEditor();
+      editor.insertText('select * from my_table;\nselect* from other_table;\nselect *\nfrom this_table\nwhere 1 = 1;');
+      expect(view.getQuery(true, true)).toEqual('select *\nfrom this_table\nwhere 1 = 1;');
     });
   });
 });


### PR DESCRIPTION
In a previous SQL client I have used, there was a convenient option to only execute the query where the cursor is located. This PR creates a new config option (`useQueryAtCursor`) for that behavior, and the necessary functionality to put that into place.

Here's a scenario; let's say we have this file in the editor:

```sql
SELECT * FROM table_one;     <when cursor is here, only select and execute THIS>

SELECT * FROM table_two;     <when cursor is here, only select and execute THIS>

SELECT *
FROM table_three
WHERE column_a = 1
AND column_b = 2;            <when cursor is here, only select and execute THIS>
```

Only the query that the cursor is in or after will be executed; this overrides the default behavior of the entire file being executed. On the other hand, if some text is already selected, then that will be executed.