### PR TITLE
Work in Progress: Add Table Schema Support and Improve Auto-complete

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -71,7 +71,7 @@ export default class DataAtomController {
   serialize() {}
 
   isEditorNotActive() {
-    return atom.workspace.getActiveTextEditor() == undefined;
+    return atom.workspace.getActiveTextEditor() === undefined;
   }
 
   // Gets or creates the ResultView state for the current editor
@@ -227,7 +227,7 @@ export default class DataAtomController {
       var dbManager = DbFactory.createDataManagerForUrl(url);
       var currentState = this.getOrCreateCurrentResultView();
       // set the view for the connection, db names will come next
-      this.mainView.setState(dbManager.getConnectionName(), [], null, currentState.useEditorAsQuery)
+      this.mainView.setState(dbManager.getConnectionName(), [], null, currentState.useEditorAsQuery);
 
       if (this.connectionList[dbManager.getConnectionName()]) {
         // don't duplicate connection, just select the connection
@@ -255,15 +255,11 @@ export default class DataAtomController {
     if (dbManager) {
     editor.dataAtomTables = null;
     editor.dataAtomColumns = null;
-      dbManager.getTableNames(database, (tables) => {
+      dbManager.getTables(database, (tables) => {
         editor.dataAtomTables = tables;
 
         dbManager.getTableDetails(database, tables, (details) => {
-          var columns = {};
-          details.forEach(function(detail) {
-            columns[detail.name] = detail.udt || detail.type;
-          });
-          editor.dataAtomColumns = columns;
+          editor.dataAtomColumns = details;
         });
       });
     }
@@ -333,15 +329,15 @@ export default class DataAtomController {
 
     this.getDataManager(executingViewState.connectionName).execute(executingViewState.database, query,
       results => {
-        this.updateStatusBar(executingTimer, start)
+        this.updateStatusBar(executingTimer, start);
         executingViewState.results = results;
         this.mainView.setResults(results);
         this.mainView.executionEnd();
       },
       err => {
-        this.updateStatusBar(executingTimer, start)
+        this.updateStatusBar(executingTimer, start);
         executingViewState.error = err;
-        this.mainView.setMessage(err)
+        this.mainView.setMessage(err);
         this.mainView.executionEnd();
       },
       queryToken => { executingViewState.queryToken = queryToken; }

--- a/lib/data-managers/mysql-manager.js
+++ b/lib/data-managers/mysql-manager.js
@@ -93,7 +93,7 @@ export default class MysqlManager extends DataManager {
   prepareRowData(rows, fields) {
     return rows.map(function(r) {
       return fields.map(function(f){
-        return "" + r[f.name]
+        return "" + r[f.name];
       });
     });
   }
@@ -124,29 +124,36 @@ export default class MysqlManager extends DataManager {
         return;
       }
 
-      onNames(rows.map(function(x) { return x.Database}));
+      onNames(rows.map(function(x) { return x.Database;}));
       connection.destroy();
     });
   }
 
-  getTableNames(database, onNames) {
-    let query = `select table_name from information_schema.tables WHERE table_schema='${database}'`;
+  getTables(database, onSuccess) {
+    let query = `select table_schema, table_name from information_schema.tables WHERE table_schema='${database}' order by table_schema, table_name`;
     this.execute(database, query, results => {
+      let tables = [];
       if (results && results.length && results[0].rows && results[0].rows.length) {
-        onNames(results[0].rows.map(function(r) { return r[0]; }));
-      } else {
-        onNames([]);
+        for (var i = 0; i < results[0].rows.length; i++) {
+          tables.push({
+            schemaName: results[0].rows[i][0],
+            name: results[0].rows[i][1]
+          });
+        }
       }
+      onSuccess(tables);
     });
   }
 
   getTableDetails(database, tables, onSuccess) {
-    var sqlTables = "('" + tables.join("','") +  "')";
+    tableNames = tables.map((t) => t.name);
+    var sqlTables = "('" + tableNames.join("','") +  "')";
 
-    let query = `SELECT column_name,data_type, character_maximum_length
+    let query = `SELECT column_name, data_type, character_maximum_length, table_name
                   FROM information_schema.columns
                   WHERE table_schema='${database}'
-                    AND table_name IN ${sqlTables}`;
+                    AND table_name IN ${sqlTables}
+                  ORDER BY table_name, ordinal_position`;
     this.execute(database, query, results => {
       let columns = [];
       for(var i = 0; i < results[0].rows.length; i++) {
@@ -154,7 +161,8 @@ export default class MysqlManager extends DataManager {
           name: results[0].rows[i][0],
           type: results[0].rows[i][1],
           udt: results[0].rows[i][1],
-          size: results[0].rows[i][2]
+          size: results[0].rows[i][2],
+          tableName: results[0].rows[i][3]
         });
       }
       onSuccess(columns);

--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -79,7 +79,7 @@ export default class PostgresManager extends DataManager {
   }
 
   checkSuperUser(callback) {
-    if(this.config.superUser == undefined) {
+    if(this.config.superUser === undefined) {
       this.execute(this.defaultDatabase, 'select usesuper from pg_user where usename = \'' + this.config.user + '\'',
         results => {
           if(results[0].rows.length > 0)
@@ -115,7 +115,7 @@ export default class PostgresManager extends DataManager {
             }
             onNames(this.dbNames);
           },
-          err => {this.dbNames = undefined}
+          err => {this.dbNames = undefined;}
         );
       });
     }
@@ -124,14 +124,20 @@ export default class PostgresManager extends DataManager {
     }
   }
 
-  getTableNames(database, onNames) {
-    this.execute(database, 'SELECT table_name FROM information_schema.tables WHERE table_schema=\'public\' and table_type = \'BASE TABLE\' order by table_name;',
+  getTables(database, onSuccess) {
+    this.execute(database, 'SELECT table_schema, table_name ' +
+                           'FROM information_schema.tables ' +
+                           'WHERE substr(table_schema, 1, 3) != \'pg_\' and table_schema != \'information_schema\' ' +
+                           'and table_type = \'BASE TABLE\' order by table_schema, table_name;',
       results => {
-        var tableNames = [];
+        var tables = [];
         for (var i = 0; i < results[0].rows.length; i++) {
-          tableNames.push(results[0].rows[i][0]);
+          tables.push({
+            schemaName: results[0].rows[i][0],
+            name: results[0].rows[i][1]
+          });
         }
-        onNames(tableNames);
+        onSuccess(tables);
       },
       err => {
         // TODO: error handling
@@ -140,9 +146,14 @@ export default class PostgresManager extends DataManager {
   }
 
   getTableDetails(database, tables, onSuccess) {
-    var sqlTables = "('" + tables.join("','") +  "')";
+    tableNames = tables.map((t) => t.name);
+    var sqlTables = "('" + tableNames.join("','") +  "')";
 
-    this.execute(database, 'select column_name, data_type, udt_name, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name IN ' + sqlTables + ';',
+    this.execute(database, 'select column_name, data_type, udt_name, character_maximum_length, table_name ' +
+                           'from INFORMATION_SCHEMA.COLUMNS ' +
+                           'where table_schema || \'.\' || table_name IN ' + sqlTables +
+                           'or table_name IN ' + sqlTables +
+                           ' order by table_name, ordinal_position;',
       results => {
         var columns = [];
         for(var i = 0; i < results[0].rows.length; i++) {
@@ -150,7 +161,8 @@ export default class PostgresManager extends DataManager {
             name: results[0].rows[i][0],
             type: results[0].rows[i][1],
             udt: results[0].rows[i][2],
-            size: results[0].rows[i][3]
+            size: results[0].rows[i][3],
+            tableName: results[0].rows[i][4]
           });
         }
         onSuccess(columns);

--- a/lib/data-managers/sqlserver-manager.js
+++ b/lib/data-managers/sqlserver-manager.js
@@ -113,20 +113,23 @@ export default class SqlServerManager extends DataManager {
         },
         err => {
           console.error('Error fetching databases:', err);
-          this.dbNames = undefined
+          this.dbNames = undefined;
         });
     } else
       onNames(this.dbNames);
   }
 
-  getTableNames(database, onNames) {
-    this.execute(database, 'SELECT table_name FROM information_schema.tables WHERE table_type = \'BASE TABLE\' order by table_name;',
+  getTables(database, onSuccess) {
+    this.execute(database, 'SELECT table_schema, table_name FROM information_schema.tables WHERE table_type = \'BASE TABLE\' order by table_schema, table_name;',
       results => {
-        var tableNames = [];
+        var tables = [];
         for (var i = 0; i < results[0].rows.length; i++) {
-          tableNames.push(results[0].rows[i][0]);
+          tables.push({
+            schemaName: results[0].rows[i][0],
+            name: results[0].rows[i][1]
+          });
         }
-        onNames(tableNames);
+        onSuccess(tables);
       },
       err => {
         console.error('Error fetching tables:', err);
@@ -136,16 +139,18 @@ export default class SqlServerManager extends DataManager {
   }
 
   getTableDetails(database, tables, onSuccess) {
-    var sqlTables = "('" + tables.join("','") +  "')";
+    tableNames = tables.map((t) => t.name);
+    var sqlTables = "('" + tableNames.join("','") +  "')";
 
-    this.execute(database, 'select column_name, data_type, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name IN ' + sqlTables + ';',
+    this.execute(database, 'select column_name, data_type, character_maximum_length, table_schema from INFORMATION_SCHEMA.COLUMNS where table_name IN ' + sqlTables + ' order by table_name, ordinal_position;',
       results => {
         var columns = [];
         for(var i = 0; i < results[0].rows.length; i++) {
           columns.push({
             name: results[0].rows[i][0],
             type: results[0].rows[i][1],
-            size: results[0].rows[i][2]
+            size: results[0].rows[i][2],
+            tableName: results[0].rows[i][3]
           });
         }
         onSuccess(columns);

--- a/lib/sql-meta-provider.js
+++ b/lib/sql-meta-provider.js
@@ -1,33 +1,91 @@
-"use babel";
+'use babel';
+import utils from './utils';
+
 var SQLMetaProvider = {
   selector: '*',
+  disableForSelector: '.source.sql .string, .source.sql .comment',
 
-  getTableNames(editor, prefix) {
+  getTableNames(editor, tablePrefix, schema) {
     let tables = editor.dataAtomTables || [];
-    let valid = tables.filter((x) => x.startsWith(prefix));
+    let valid = tables.filter((table) => {
+      if (schema) {
+        return table.schemaName === schema && table.name.startsWith(tablePrefix);
+      } else if (tablePrefix) {
+        return table.name.startsWith(tablePrefix) || table.schemaName.startsWith(tablePrefix);
+      }
+    });
     return valid.map((table) => {
       return {
-        text: table,
+        text: (schema) ? table.name : table.schemaName + '.' + table.name,
         rightLabel: 'Table'
       };
     });
   },
 
-  getColumnNames(editor, prefix) {
-    let columns = Object.keys(editor.dataAtomColumns || {});
-    let valid = columns.filter((x) => x.startsWith(prefix));
-    return valid.map((column) => {
-      return {
-        text: column,
-        rightLabel: 'Column',
-        leftLabel: editor.dataAtomColumns[column]
+  getColumnNames(editor, columnPrefix, objectName) {
+    let columns = editor.dataAtomColumns || [];
+    let valid = columns.filter((col) => {
+      if (objectName) {
+        return col.tableName === objectName && col.name.startsWith(columnPrefix);
+      } else if (columnPrefix) {
+        return col.name.startsWith(columnPrefix);
       }
+    });
+    return valid.map((col) => {
+      return {
+        text: col.name,
+        rightLabel: 'Column',
+        leftLabel: col.type || col.udt
+      };
     });
   },
 
-  getSuggestions: function({editor, bufferPosition, scopeDescriptor, prefix, activatedManually}) {
-    return this.getTableNames(editor, prefix).concat(this.getColumnNames(editor, prefix));
+  getAliasedObject(editor, lastIdentifier) {
+    let query = editor.getBuffer().getTextInRange(utils.getRangeForQueryAtCursor(editor));
+    let matches = query.match(new RegExp('([\\w0-9]*)\\s*(?:AS)?\\s*' + lastIdentifier + '[\\s;]', 'i'));
+    if (matches) {
+      return matches[matches.length - 1];
+    } else {
+      return null;
+    }
+  },
+
+  getPrefix(editor, bufferPosition) {
+    let line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]);
+    let matches = line.match(/[\w\.]+$/);
+    if (matches) {
+      return matches[0] || '';
+    } else {
+      return '';
+    }
+  },
+
+  getSuggestions({editor, bufferPosition, scopeDescriptor}) {
+    let prefix = this.getPrefix(editor, bufferPosition);
+    let identifiers = prefix.split('.');
+    let identsLength = identifiers.length;
+    let results = [];
+
+    if (identsLength) {
+      let lastIdentifier = (identsLength > 1) && identifiers[identsLength - 2];
+      let search = identifiers[identsLength - 1];
+      results = this.getColumnNames(editor, search, lastIdentifier).concat(this.getTableNames(editor, search, lastIdentifier));
+      // If there are no results, check for alias
+      if (!results.length) {
+        let tableName = this.getAliasedObject(editor, lastIdentifier);
+        if (tableName) {
+          // Get by matched alias table
+          results = this.getColumnNames(editor, search, tableName);
+        }
+      }
+    }
+
+    if (prefix && !results.length) {
+      results = this.getTableNames(editor, prefix, null).concat(this.getColumnNames(editor, prefix, null));
+    }
+
+    return results;
   }
-}
+};
 
 export default SQLMetaProvider;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,5 +14,22 @@ module.exports = {
     dbOptions.split(',').map(s => optionsStr += s.trim() + '&');
     optionsStr = _s.rtrim(optionsStr, '&');
     return optionsStr;
+  },
+
+  getRangeForQueryAtCursor: function(editor) {
+    let queryEndRegex = /^.*\;$/;
+    let currentCursorRow = editor.getCursorBufferPosition().row;
+    let range = [[0], [editor.getLastBufferRow() + 1]];
+    editor.scanInBufferRange(queryEndRegex, [[currentCursorRow], [editor.getLastBufferRow() + 1]],
+      function(endMatch) {
+        range[1] = [endMatch.range.start.row + 1];
+        return endMatch.stop();
+    });
+    editor.backwardsScanInBufferRange(queryEndRegex, [[0], [currentCursorRow]],
+      function(startMatch) {
+        range[0] = [startMatch.range.start.row + 1];
+        return startMatch.stop();
+    });
+    return range;
   }
-}
+};

--- a/lib/views/data-atom-view.js
+++ b/lib/views/data-atom-view.js
@@ -2,6 +2,7 @@
 
 import DataResultView from './data-result-view';
 import HeaderView from './header-view';
+import utils from '../utils';
 
 import {TextEditor, Emitter} from 'atom';
 
@@ -64,30 +65,14 @@ export default class DataAtomView {
     if (useEditorAsQuery) {
       var selectedText = editor.getSelectedText();
       if (useQueryAtCursor && !selectedText) {
-        selectedText = this.getQueryAtCursor(editor, selectedText);
+        var selectionRange = utils.getRangeForQueryAtCursor(editor);
+        editor.setSelectedBufferRange(selectionRange);
+        selectedText = editor.getSelectedText();
       }
       return selectedText ? selectedText : editor.getText();
     } else {
       return this.queryEditor.getModel().getText();
     }
-  }
-
-  getQueryAtCursor(editor, selectedText) {
-    var queryEndRegex = /^.*\;$/;
-    var currentCursorRow = editor.getCursorBufferPosition().row;
-    var selectionRange = [[0], [0]];
-    editor.scanInBufferRange(queryEndRegex, [[currentCursorRow], [editor.getLastBufferRow() + 1]],
-      function(endMatch) {
-        selectionRange[1] = [endMatch.range.start.row + 1];
-        endMatch.stop();
-    });
-    editor.backwardsScanInBufferRange(queryEndRegex, [[0], [currentCursorRow]],
-      function(startMatch) {
-        selectionRange[0] = [startMatch.range.start.row + 1];
-        startMatch.stop();
-    });
-    editor.setSelectedBufferRange(selectionRange);
-    return editor.getSelectedText();
   }
 
   getSelectedDatabase() {

--- a/lib/views/data-details-view.js
+++ b/lib/views/data-details-view.js
@@ -72,25 +72,26 @@ export default class DataDetailsView {
   buildTableList(element, database) {
     var tableList = document.createElement('ol');
     tableList.className = 'table-list list-tree';
-    this.DbManager.getTableNames(database, (names) => {
-      for(var i = 0; i < names.length; i++) {
+    this.DbManager.getTables(database, (tables) => {
+      for(var i = 0; i < tables.length; i++) {
         var tbl = document.createElement('li');
         tbl.className = 'tbl collapsed list-nested-item';
+        tbl.title = tables[i].schemaName;
         tbl.addEventListener('click', e => this.toggleCollapsed(e));
         var div = document.createElement('div');
         div.classList.add('table-name');
-        div.innerText = names[i];
+        div.innerText = tables[i].name;
         tbl.appendChild(div);
         tableList.appendChild(tbl);
       }
-    })
+    });
     element.appendChild(tableList);
   }
 
   buildTableDetails(element, table, database) {
     var columnList = document.createElement('ol');
     columnList.className = 'column-list list-tree';
-    this.DbManager.getTableDetails(database, [table], (columns) => {
+    this.DbManager.getTableDetails(database, [{name: table}], (columns) => {
       for(var i = 0; i < columns.length; i++) {
         var col = document.createElement('li');
         col.className = 'col list-nested-item';
@@ -103,7 +104,7 @@ export default class DataDetailsView {
         col.appendChild(div);
         columnList.appendChild(col);
       }
-    })
+    });
     element.appendChild(columnList);
   }
 
@@ -175,12 +176,12 @@ export default class DataDetailsView {
 
   resizeDetailsView(e) {
     if(this.getPosition() === 'right') {
-      var width = atom.getSize().width - e.pageX;
+      let width = atom.getSize().width - e.pageX;
       this.element.style.width = width + 'px';
     }
     else
     {
-      var width = e.pageX - this.element.offsetParent.offsetLeft;
+      let width = e.pageX - this.element.offsetParent.offsetLeft;
       this.element.style.width = width + 'px';
     }
   }

--- a/spec/sql-meta-provider-spec.js
+++ b/spec/sql-meta-provider-spec.js
@@ -6,9 +6,21 @@ describe('SQLMetaProvider', () => {
   describe('Get table names', () => {
     it('filters by prefix', () => {
       let editor = {
-        dataAtomTables: ['test_table', 'other_table', 'test_table_2']
-      }
-      let tables = SQLMetaProvider.getTableNames(editor, 'test');
+        dataAtomTables: [
+          {
+            name: 'test_table',
+            schemaName: 'something'
+          },
+          {
+            name: 'other_table',
+            schemaName: 'something'
+          },
+          {
+            name: 'test_table_2',
+            schemaName: 'something'
+          }
+      ]};
+      let tables = SQLMetaProvider.getTableNames(editor, 'test', 'something');
 
       expect(tables).not.toContain({text: 'other_table', rightLabel: 'Table'});
       expect(tables).toContain({text: 'test_table', rightLabel: 'Table'});
@@ -20,12 +32,20 @@ describe('SQLMetaProvider', () => {
   describe('Get column names', () => {
     it('filters by prefix', () => {
       let editor = {
-        dataAtomColumns: {
-          'test_col': 'varchar',
-          'other_col': 'bool'
-        }
+        dataAtomColumns: [
+          {
+            name: 'test_col',
+            tableName: 'tbl',
+            type: 'varchar'
+          },
+          {
+            name: 'other_col',
+            tableName: 'tbl',
+            type: 'bool'
+          }
+        ]
       };
-      let cols = SQLMetaProvider.getColumnNames(editor, 'test');
+      let cols = SQLMetaProvider.getColumnNames(editor, 'test', 'tbl');
       expect(cols).toContain({text: 'test_col', rightLabel: 'Column', leftLabel: 'varchar'});
       expect(cols.length).toEqual(1);
     });

--- a/styles/data-atom.less
+++ b/styles/data-atom.less
@@ -6,7 +6,7 @@
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(atom://data-atom/resources/fontawesome-webfont.woff2) format('woff2');
+  src: url('atom://data-atom/resources/fontawesome-webfont.woff2') format('woff2');
 }
 
 // put all our styling under this to minimise clashes


### PR DESCRIPTION
I have not tested this for MySQL or SQL Server...only Postgres. I don't think they will be a problem, but these should be tested before a merge to master, I think. Feel free to offer any suggestions, comments, or concerns.

Schema Support:
Some databases (namely Postgres) can namespace by schema. This change modifies getting tables from the information_schema by making the tables a list of objects (includes table name and schema) rather than before which was just an array of table names. Schemas are now part of auto-completion results for tables. This would resolve issue #54.

More Intelligent Auto-completion:
In past SQL clients, I have loved the feature of auto-completion of columns within the context of a table. Column objects that are fetched from the information_schema now also get the table name that the column belongs to. Doing this allows for auto-completion after specifying the table the column is from using dot notation. For example typing `my_table.` would get a list of columns for that table only, ordered by their ordinal position on the table. Table aliases also work, for example, `SELECT * FROM my_table AS mt WHERE mt.` would also show auto-completion for the columns of that table only.