### PR TITLE
Add views to auto-complete suggestions

### DIFF
--- a/lib/data-managers/mysql-manager.js
+++ b/lib/data-managers/mysql-manager.js
@@ -130,14 +130,15 @@ export default class MysqlManager extends DataManager {
   }
 
   getTables(database, onSuccess) {
-    let query = `select table_schema, table_name from information_schema.tables WHERE table_schema='${database}' order by table_schema, table_name`;
+    let query = `select table_schema, table_name, table_type from information_schema.tables WHERE table_schema='${database}' order by table_schema, table_type, table_name`;
     this.execute(database, query, results => {
       let tables = [];
       if (results && results.length && results[0].rows && results[0].rows.length) {
         for (var i = 0; i < results[0].rows.length; i++) {
           tables.push({
             schemaName: results[0].rows[i][0],
-            name: results[0].rows[i][1]
+            name: results[0].rows[i][1],
+            type: results[0].rows[i][2] === 'BASE TABLE' ? 'Table' : 'View'
           });
         }
       }

--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -125,16 +125,17 @@ export default class PostgresManager extends DataManager {
   }
 
   getTables(database, onSuccess) {
-    this.execute(database, 'SELECT table_schema, table_name ' +
+    this.execute(database, 'SELECT table_schema, table_name, table_type ' +
                            'FROM information_schema.tables ' +
                            'WHERE substr(table_schema, 1, 3) != \'pg_\' and table_schema != \'information_schema\' ' +
-                           'and table_type = \'BASE TABLE\' order by table_schema, table_name;',
+                           'order by table_schema, table_type, table_name;',
       results => {
         var tables = [];
         for (var i = 0; i < results[0].rows.length; i++) {
           tables.push({
             schemaName: results[0].rows[i][0],
-            name: results[0].rows[i][1]
+            name: results[0].rows[i][1],
+            type: results[0].rows[i][2] === 'BASE TABLE' ? 'Table' : 'View'
           });
         }
         onSuccess(tables);

--- a/lib/data-managers/sqlserver-manager.js
+++ b/lib/data-managers/sqlserver-manager.js
@@ -120,13 +120,14 @@ export default class SqlServerManager extends DataManager {
   }
 
   getTables(database, onSuccess) {
-    this.execute(database, 'SELECT table_schema, table_name FROM information_schema.tables WHERE table_type = \'BASE TABLE\' order by table_schema, table_name;',
+    this.execute(database, 'SELECT table_schema, table_name, table_type FROM information_schema.tables order by table_schema, table_type, table_name;',
       results => {
         var tables = [];
         for (var i = 0; i < results[0].rows.length; i++) {
           tables.push({
             schemaName: results[0].rows[i][0],
-            name: results[0].rows[i][1]
+            name: results[0].rows[i][1],
+            type: results[0].rows[i][2] === 'BASE TABLE' ? 'Table' : 'View'
           });
         }
         onSuccess(tables);

--- a/lib/sql-meta-provider.js
+++ b/lib/sql-meta-provider.js
@@ -17,7 +17,7 @@ var SQLMetaProvider = {
     return valid.map((table) => {
       return {
         text: (schema) ? table.name : table.schemaName + '.' + table.name,
-        rightLabel: 'Table'
+        rightLabel: table.type
       };
     });
   },

--- a/spec/sql-meta-provider-spec.js
+++ b/spec/sql-meta-provider-spec.js
@@ -9,15 +9,18 @@ describe('SQLMetaProvider', () => {
         dataAtomTables: [
           {
             name: 'test_table',
-            schemaName: 'something'
+            schemaName: 'something',
+            type: 'Table'
           },
           {
             name: 'other_table',
-            schemaName: 'something'
+            schemaName: 'something',
+            type: 'Table'
           },
           {
             name: 'test_table_2',
-            schemaName: 'something'
+            schemaName: 'something',
+            type: 'Table'
           }
       ]};
       let tables = SQLMetaProvider.getTableNames(editor, 'test', 'something');


### PR DESCRIPTION
Add views to auto-complete suggestions for all supported database platforms. I only tested this with Postgres, but this should work with the other platforms as well.