### PR TITLE
Make horizontal table scrolling more user-friendly

### DIFF
--- a/lib/views/data-result-view.js
+++ b/lib/views/data-result-view.js
@@ -34,9 +34,7 @@ export default class DataResultView {
     }
     return <div className='results-section'>
       <span className='heading-title'>Results:</span>
-      <div className='scollable'>
-        {content}
-      </div>
+      {content}
     </div>;
   }
 

--- a/styles/data-atom.less
+++ b/styles/data-atom.less
@@ -200,7 +200,6 @@
 
     .result-table {
       margin-bottom: 15px;
-      overflow-x: auto;
       -webkit-user-select: none;
       user-select: none;
     }


### PR DESCRIPTION
This makes the results table horizontal scroll bar always visible (when it is necessary). Before, for a record set that was larger than the visible area, you would have to vertically scroll to the bottom of the table in order to horizontally scroll.