### PR TITLE
Postgres: allow the error dialog to display more information

### DIFF
--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -43,7 +43,7 @@ export default class PostgresManager extends DataManager {
   }
 
   buildErrorMessage(err) {
-    return err.toString();
+    return err.toString() + '\n' + (err.where || '');
   }
 
   cancelExecution(queryToken) {

--- a/lib/views/data-result-view.js
+++ b/lib/views/data-result-view.js
@@ -20,7 +20,7 @@ export default class DataResultView {
   render() {
     var content;
     if (this.state.message) {
-      content = (<span>{JSON.stringify(this.state.message)}</span>)
+      content = this.state.message.split('\n').map(line => <div>{line}</div>);
     }
     else {
       content = this.state.results.map(result =>


### PR DESCRIPTION
The error message by itself is rather simplistic. This change expands on the error message for postgres, adding the "where" property, which can be very helpful in catching syntax errors (most DB IDE's do this too).

Also, I made a change to the database error message view to display each message on a new line, without stringifying the message; this makes the message look "prettier" (no more escaped characters like `error: \"You messed up!\"`)