### PR TITLE
Resolve occasional of out-of-sync results state

### DIFF
--- a/lib/views/table-view.js
+++ b/lib/views/table-view.js
@@ -41,6 +41,8 @@ export default class DataResultView {
   }
 
   update(props, children) {
+    this.state.columns = props.columns;
+    this.state.rows = props.rows;
     return etch.update(this);
   }
 


### PR DESCRIPTION
Currently, the results of the query actually executed are not displayed if a previous query is run. The user has to execute the query again to get the correct results to display. The root cause is that etch is doing an update of the table-view without updating the results state for that view.

### Steps to reproduce:

1. Execute a query in the editor.
2. On a new line, execute another query that will display different
results, like `select current_timestamp;`.
3. Go back to the first query and execute. The results will not change.
If you cannot reproduce, repeat these steps multiple times.