### PR TITLE
Add column autocompletion for insert statements

### DIFF
--- a/lib/data-atom.js
+++ b/lib/data-atom.js
@@ -2,11 +2,12 @@
 
 import DataAtomController from './data-atom-controller';
 import StatusBarManager from './status-bar-manager';
-import SQLMetaProvider from './sql-meta-provider';
+import InsertMetaProvider from './providers/insert-meta-provider';
+import SQLMetaProvider from './providers/sql-meta-provider';
 
 export default {
   provide: function() {
-    return SQLMetaProvider;
+    return [InsertMetaProvider, SQLMetaProvider];
   },
 
   config: {

--- a/lib/providers/insert-meta-provider.js
+++ b/lib/providers/insert-meta-provider.js
@@ -1,0 +1,76 @@
+'use babel';
+import utils from '../utils';
+
+class InsertMetaProvider {
+
+  constructor() {
+    this.selector = '*';
+    this.disableForSelector = '.source.sql .string, .source.sql .comment';
+    this.labelHTML = `<span class="data-atom autocomplete autocomplete-col"></span>Column`;
+  }
+
+  getTableColumnNames(editor, tableName, existingColumns) {
+    let columns = editor.dataAtomColumns || [];
+    let valid = columns.filter(col => col.tableName === tableName && existingColumns.indexOf(col.name) < 0);
+    let labels = valid.map(col => {
+      return {
+        text: col.name,
+        rightLabelHTML: this.labelHTML,
+        leftLabel: col.type || col.udt
+      };
+    });
+    if (!existingColumns.length && labels.length) {
+      let cols = [];
+      let vals = [];
+      valid.forEach((col, i) => {
+          let nameText = col.type === 'character varying' ? `'${col.name}'` : col.name;
+          vals.push(`\${${(i + 1).toString()}:${nameText}}`);
+          cols.push(col.name);
+      });
+      labels.unshift({
+        snippet: `(${cols.join(', ')})\nvalues(${vals.join(', ')})`,
+        displayText: 'Insert snippet…',
+        rightLabelHTML: this.labelHTML,
+        leftLabel: 'All'
+      });
+    }
+    return labels;
+  }
+
+  getMatch(editor, bufferPosition) {
+    let line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]);
+    let matches = line.match(/insert\s+into\s+([\w\.]+)\s\(?(.*)\)?$/i);
+    let match = {
+        schema: '',
+        tableName: '',
+        existingColumns: []
+    }
+    if (matches) {
+      let tableQualified = matches[1] || '';
+      let tableWithSchema = tableQualified.split('.');
+
+      match.tableName = tableWithSchema.pop();
+      if (tableWithSchema.length) {
+          match.schema = tableWithSchema.pop();
+      }
+      if (matches.length > 2 && matches[2]) {
+        match.existingColumns = matches[2].split(/,\s?/g)
+      }
+
+    }
+    return match;
+  }
+
+  getSuggestions({editor, bufferPosition, scopeDescriptor}) {
+    return new Promise(resolve => {
+      let match = this.getMatch(editor, bufferPosition);
+      if (match.tableName) {
+        resolve(this.getTableColumnNames(editor, match.tableName, match.existingColumns));
+      } else {
+        resolve([]);
+      }
+    });
+  }
+}
+
+export default new InsertMetaProvider();

--- a/lib/providers/sql-meta-provider.js
+++ b/lib/providers/sql-meta-provider.js
@@ -1,9 +1,12 @@
 'use babel';
-import utils from './utils';
+import utils from '../utils';
 
-var SQLMetaProvider = {
-  selector: '*',
-  disableForSelector: '.source.sql .string, .source.sql .comment',
+class SQLMetaProvider {
+
+  constructor() {
+    this.selector = '*';
+    this.disableForSelector = '.source.sql .string, .source.sql .comment'
+  }
 
   getTableNames(editor, tablePrefix, schema) {
     let tables = editor.dataAtomTables || [];
@@ -20,7 +23,7 @@ var SQLMetaProvider = {
         rightLabelHTML: `<span class="data-atom autocomplete autocomplete-tbl"></span>${table.type}`
       };
     });
-  },
+  }
 
   getColumnNames(editor, columnPrefix, objectName) {
     let columns = editor.dataAtomColumns || [];
@@ -34,11 +37,11 @@ var SQLMetaProvider = {
     return valid.map((col) => {
       return {
         text: col.name,
-        rightLabelHTML: `<span class="data-atom autocomplete autocomplete-col"></span>Column`,
+        rightLabelHTML: '<span class="data-atom autocomplete autocomplete-col"></span>Column',
         leftLabel: col.type || col.udt
       };
     });
-  },
+  }
 
   getAliasedObject(editor, lastIdentifier) {
     let query = editor.getBuffer().getTextInRange(utils.getRangeForQueryAtCursor(editor));
@@ -48,7 +51,7 @@ var SQLMetaProvider = {
     } else {
       return null;
     }
-  },
+  }
 
   getPrefix(editor, bufferPosition) {
     let line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]);
@@ -58,34 +61,36 @@ var SQLMetaProvider = {
     } else {
       return '';
     }
-  },
+  }
 
   getSuggestions({editor, bufferPosition, scopeDescriptor}) {
-    let prefix = this.getPrefix(editor, bufferPosition);
-    let identifiers = prefix.split('.');
-    let identsLength = identifiers.length;
-    let results = [];
+    return new Promise(resolve => {
+      let prefix = this.getPrefix(editor, bufferPosition);
+      let identifiers = prefix.split('.');
+      let identsLength = identifiers.length;
+      let results = [];
 
-    if (identsLength) {
-      let lastIdentifier = (identsLength > 1) && identifiers[identsLength - 2];
-      let search = identifiers[identsLength - 1];
-      results = this.getColumnNames(editor, search, lastIdentifier).concat(this.getTableNames(editor, search, lastIdentifier));
-      // If there are no results, check for alias
-      if (!results.length) {
-        let tableName = this.getAliasedObject(editor, lastIdentifier);
-        if (tableName) {
-          // Get by matched alias table
-          results = this.getColumnNames(editor, search, tableName);
+      if (identsLength) {
+        let lastIdentifier = (identsLength > 1) && identifiers[identsLength - 2];
+        let search = identifiers[identsLength - 1];
+        results = this.getColumnNames(editor, search, lastIdentifier).concat(this.getTableNames(editor, search, lastIdentifier));
+        // If there are no results, check for alias
+        if (!results.length) {
+          let tableName = this.getAliasedObject(editor, lastIdentifier);
+          if (tableName) {
+            // Get by matched alias table
+            results = this.getColumnNames(editor, search, tableName);
+          }
         }
       }
-    }
 
-    if (prefix && !results.length) {
-      results = this.getTableNames(editor, prefix, null).concat(this.getColumnNames(editor, prefix, null));
-    }
+      if (prefix && !results.length) {
+        results = this.getTableNames(editor, prefix, null).concat(this.getColumnNames(editor, prefix, null));
+      }
 
-    return results;
+      resolve(results);
+    });
   }
-};
+}
 
-export default SQLMetaProvider;
+export default new SQLMetaProvider();

--- a/spec/meta-provider-spec.js
+++ b/spec/meta-provider-spec.js
@@ -1,6 +1,34 @@
 'use babel';
 
-import SQLMetaProvider from '../lib/sql-meta-provider';
+import InsertMetaProvider from '../lib/providers/insert-meta-provider';
+import SQLMetaProvider from '../lib/providers/sql-meta-provider';
+
+describe('InsertMetaProvider', () => {
+  describe('Get columns', () => {
+  let editor = {
+    dataAtomColumns: [{
+        name: 'test_col',
+        tableName: 'tbl',
+        type: 'varchar'
+      },
+      {
+        name: 'other_col',
+        tableName: 'tbl',
+        type: 'bool'
+      }]
+    };
+    it('filters by table name including the ALL suggestion when no previous columns exist', () => {
+        let cols = InsertMetaProvider.getTableColumnNames(editor, 'tbl', []);
+        expect(cols).toContain({text: 'test_col', rightLabelHTML: '<span class="data-atom autocomplete autocomplete-col"></span>Column', leftLabel: 'varchar'});
+        expect(cols.length).toEqual(3);
+    });
+    it('filters by table name and only includes columns that are not existing already', () => {
+        let cols = InsertMetaProvider.getTableColumnNames(editor, 'tbl', ['test_col']);
+        expect(cols).toContain({text: 'other_col', rightLabelHTML: '<span class="data-atom autocomplete autocomplete-col"></span>Column', leftLabel: 'bool'});
+        expect(cols.length).toEqual(1);
+    });
+  })
+});
 
 describe('SQLMetaProvider', () => {
   describe('Get table names', () => {


### PR DESCRIPTION
This feature adds auto-completion for SQL insert statements by giving table columns as autocomplete suggestions, as well as adding an "ALL" suggestion that adds all column names in column order, comma separated. If columns have already been typed/auto-completed, they will not show in the autocomplete suggestions.

### Example of entire `insert` statement auto-completion
Typing the following:
```sql
insert into countries 
```

Produces this tab-completable snippet:
```sql
insert into countries (name, country_code)
values (${1:'name'}, ${2:'country_code'})
```

Which to the user looks like:
```sql
insert into countries (name, country_code)
values ('name', 'country_code')
```

The auto-completion detects whether a column's type is `character varying` or not, and inserts quotes accordingly.

This addresses the feature request of #86.