### PR TITLE
Add error checking to avoid throwing major errors

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -267,6 +267,8 @@ export default class DataAtomController {
         dbManager.getTableDetails(database, tables).then(details => {
           editor.dataAtomColumns = details;
         });
+      }).catch(err => {
+        this.mainView.setMessage(err);
       });
     }
   }

--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -97,7 +97,7 @@ export default class PostgresManager extends DataManager {
       });
     }
     else
-      Promise.resolve();
+      return Promise.resolve();
   }
 
   getDatabaseNames() {
@@ -118,7 +118,8 @@ export default class PostgresManager extends DataManager {
           return this.dbNames;
         })
         .catch(err => { this.dbNames = undefined; });
-      });
+      })
+      .catch(err => { this.dbNames = undefined; });
     }
     else
       return Promise.resolve(this.dbNames);
@@ -141,7 +142,7 @@ export default class PostgresManager extends DataManager {
       return tables;
     })
     .catch(err => {
-      // TODO: error handling
+      return Promise.resolve([]);
     });
   }
 
@@ -168,7 +169,7 @@ export default class PostgresManager extends DataManager {
       return columns;
     })
     .catch(err => {
-      // TODO: error handling
+      return Promise.resolve([])
     });
   }
 }

--- a/lib/views/data-details-view.js
+++ b/lib/views/data-details-view.js
@@ -55,6 +55,9 @@ export default class DataDetailsView {
     this.dbListContainer.classList.remove('hidden');
     while(this.dbList.firstChild) this.dbList.removeChild(this.dbList.firstChild);
     this.DbManager.getDatabaseNames().then(names => {
+      if (!names)
+        return;
+
       for(var i = 0; i < names.length; i++) {
         var db = document.createElement('li');
         db.classList.add('db');
@@ -66,7 +69,7 @@ export default class DataDetailsView {
         db.appendChild(div);
         this.dbList.appendChild(db);
       }
-    });
+  });
   }
 
   buildTableList(element, database) {


### PR DESCRIPTION
Currently, when a database connection is invalid or unhealthy, errors are throw up to atom core. This commit adds some basic error checking to avoid trying to do database connection dependent actions without a valid database connection.

Instead, nothing is done and an error message is shown in the results view.

This would take care of #91.