### PR TITLE
Quick query table from details view

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -41,6 +41,7 @@ export default class DataAtomController {
     atom.commands.add('atom-workspace', 'data-atom:toggle-details-view', () => this.toggleDetailsView());
     atom.commands.add('atom-workspace', 'data-atom:toggle-query-source', () => this.toggleQuerySource());
     atom.commands.add('atom-workspace', 'data-atom:edit-connections', () => this.editConnections());
+    atom.commands.add('atom-workspace', 'data-atom:query-table', (el) => this.queryTable(el));
     atom.workspace.onDidChangeActivePaneItem(() => this.onActivePaneChanged());
     atom.workspace.onDidDestroyPaneItem((e) => {
       if (e.item && e.item.id && this.viewStateToEditor[e.item.id])
@@ -300,6 +301,28 @@ export default class DataAtomController {
         atom.workspace.open(DbFactory.file());
       }
     });
+  }
+
+  /**
+   * Query table
+   */
+  queryTable(el) {
+    if (this.isEditorNotActive())
+      return;
+
+    if (!this.mainView.isShowing)
+      this.showMainView();
+
+    var query = 'SELECT * FROM ' + el.target.innerText + ' LIMIT 100';
+
+    this.getOrCreateCurrentResultView().useEditorAsQuery = false;
+    this.mainView.useEditorAsQuerySource(false);
+    this.mainView.focusQueryInput();
+    this.mainView.setQuery(query);
+    this.mainView.show();
+
+    var currentViewState = this.getOrCreateCurrentResultView();
+    this.actuallyExecute(currentViewState, query);
   }
 
   /**

--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -313,7 +313,8 @@ export default class DataAtomController {
     if (!this.mainView.isShowing)
       this.showMainView();
 
-    var query = 'SELECT * FROM ' + el.target.innerText + ' LIMIT 100';
+    var currentViewState = this.getOrCreateCurrentResultView();
+    var query = this.getDataManager(currentViewState.connectionName).getTableQuery(el.target.innerText);
 
     this.getOrCreateCurrentResultView().useEditorAsQuery = false;
     this.mainView.useEditorAsQuerySource(false);
@@ -321,7 +322,6 @@ export default class DataAtomController {
     this.mainView.setQuery(query);
     this.mainView.show();
 
-    var currentViewState = this.getOrCreateCurrentResultView();
     this.actuallyExecute(currentViewState, query);
   }
 

--- a/lib/data-managers/data-manager.js
+++ b/lib/data-managers/data-manager.js
@@ -65,4 +65,9 @@ export default class DataManager {
    * @returns a Promise. resolving an array of details
    */
   getTableDetails(database, tables) {}
+  /**
+   * Generate a SQL query to select first 100 rows
+   * @returns a string
+   */
+  getTableQuery(table) {}
 }

--- a/lib/data-managers/mysql-manager.js
+++ b/lib/data-managers/mysql-manager.js
@@ -179,4 +179,8 @@ export default class MysqlManager extends DataManager {
       return columns;
     });
   }
+
+  getTableQuery(table) {
+    return 'SELECT * FROM ' + table + ' LIMIT 100';
+  }
 }

--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -172,4 +172,8 @@ export default class PostgresManager extends DataManager {
       return Promise.resolve([])
     });
   }
+
+  getTableQuery(table) {
+    return 'SELECT * FROM ' + table + ' LIMIT 100';
+  }
 }

--- a/lib/data-managers/sqlserver-manager.js
+++ b/lib/data-managers/sqlserver-manager.js
@@ -160,4 +160,8 @@ export default class SqlServerManager extends DataManager {
       }
     );
   }
+
+  getTableQuery(table) {
+    return 'SELECT * FROM ' + table + ' LIMIT 100';
+  }
 }

--- a/lib/views/data-atom-view.js
+++ b/lib/views/data-atom-view.js
@@ -75,6 +75,10 @@ export default class DataAtomView {
     }
   }
 
+  setQuery(query) {
+    this.queryEditor.getModel().setText(query);
+  }
+
   getSelectedDatabase() {
     return this.headerView.getSelectedDatabase();
   }

--- a/menus/data-atom.cson
+++ b/menus/data-atom.cson
@@ -2,6 +2,9 @@
 'context-menu':
   'atom-text-editor': [
     { 'label': 'Data Atom - Execute', 'command': 'data-atom:execute' }
+  ],
+  '.db-list .table-name': [
+    { 'label': 'Query Table', 'command': 'data-atom:query-table' }
   ]
 
 'menu': [


### PR DESCRIPTION
I'm not sure if you wish to support this functionality or not but I've implemented it in my version and thought I'd share for anyone interested.

Added a context menu so when you right click a table on the details view you have the option to "Query Table" which will run a SELECT * FROM {table} LIMIT 100.

![screenshot from 2016-09-26 14-04-41](https://cloud.githubusercontent.com/assets/889164/18849947/87ea7e6a-83f2-11e6-86bc-7528929ef247.png)
