### PR TITLE
Update styling selector from deprecated version

### DIFF
--- a/styles/data-atom.less
+++ b/styles/data-atom.less
@@ -80,7 +80,7 @@
       margin-bottom: 0;
     }
 
-    .editor.mini {
+    atom-text-editor[mini] {
       margin-bottom: 0;
     }
 


### PR DESCRIPTION
`.editor.mini` is deprecated in a recent version of Atom. This commit updates the selector to one suggested by Atom. This addresses #99.