### PR TITLE
Fix deprecation warning from setting editor height

### DIFF
--- a/lib/views/data-atom-view.js
+++ b/lib/views/data-atom-view.js
@@ -35,11 +35,12 @@ export default class DataAtomView {
     title.innerText = 'Query:';
     this.querySection.appendChild(title);
 
-    this.queryEditor = document.createElement('atom-text-editor');
+    var textEditor = atom.workspace.buildTextEditor();
+    textEditor.autoHeight = false;
+    this.queryEditor = textEditor.getElement();
     this.queryEditor.classList.add('query-input');
     this.queryEditor.style.height = '40px';
     this.queryEditor.style.maxHeight = '40px';
-    // this.queryEditor.getModel().setGrammar('sql');
     this.querySection.appendChild(this.queryEditor);
 
     this.resultsView = new DataResultView();


### PR DESCRIPTION
Atom wants the `autoHeight` property on the editor set to `false` explicitly now. Before, it was always done implicitly. A deprecation warning was being raised before. See https://github.com/atom/atom/pull/12445.
