### PR TITLE
Closes #128.

### DIFF
--- a/lib/data-atom-controller.js
+++ b/lib/data-atom-controller.js
@@ -37,6 +37,12 @@ export default class DataAtomController {
     atom.commands.add('atom-workspace', 'data-atom:new-connection', () => this.createNewConnection());
     atom.commands.add('atom-workspace', 'data-atom:new-query', () => this.newQuery());
     atom.commands.add('atom-workspace', 'data-atom:execute', () => this.execute());
+    atom.commands.add('atom-workspace', 'data-atom:execute Current Paragraph', () => {
+      editor = atom.workspace.getActiveTextEditor();
+      editor.moveToBeginningOfNextParagraph();
+      editor.selectToBeginningOfPreviousParagraph();
+      this.execute();
+    });
     atom.commands.add('atom-workspace', 'data-atom:toggle-results-view', () => this.toggleMainView());
     atom.commands.add('atom-workspace', 'data-atom:toggle-details-view', () => this.toggleDetailsView());
     atom.commands.add('atom-workspace', 'data-atom:toggle-query-source', () => this.toggleQuerySource());

--- a/lib/data-managers/postgres-manager.js
+++ b/lib/data-managers/postgres-manager.js
@@ -6,9 +6,6 @@ import DataManager from './data-manager';
 export default class PostgresManager extends DataManager {
   constructor(dbConfig) {
     super(dbConfig);
-
-    this.dbConfig.user = encodeURIComponent(this.dbConfig.user);
-    this.dbConfig.password = encodeURIComponent(this.dbConfig.password);
   }
 
   destroy() {


### PR DESCRIPTION
Remove URI encoding from `postgres-manager` since this is already centrally handled in `db-connection-config`.