### PR TITLE
Fix #114 - Refresh of MySQL connection pool to reflect DB dropdown change.

### DIFF
--- a/lib/data-managers/mysql-manager.js
+++ b/lib/data-managers/mysql-manager.js
@@ -22,7 +22,7 @@ export default class MysqlManager extends DataManager {
   execute(database, query, onQueryToken) {
     return new Promise((resolve, reject) => {
       var url = database !== '' ? this.dbConfig.getUrlWithDb(database) : this.dbConfig.getUrl();
-      if (!this.pool) {
+      if (!this.pool || this.pool.config.connectionConfig.database !== database) {
         let config = {
           host: this.dbConfig.server,
           user: this.dbConfig.user,


### PR DESCRIPTION
A proposed fix for issue #114 - caused by the MySQL dataManager not checking for a change of the database variable after the initial pool is created. 

If new database does not match the current pool config, a new pool is created.