### PR TITLE
set  SQLMetaProvider to observe & respect the autocomplete+ minimum word length

### DIFF
--- a/lib/providers/sql-meta-provider.js
+++ b/lib/providers/sql-meta-provider.js
@@ -7,6 +7,10 @@ class SQLMetaProvider {
     this.selector = '*';
     this.disableForSelector = '.source.sql .string, .source.sql .comment'
     this.filterSuggestions = true;
+    atom.config.observe( // called immediately and on update
+      'autocomplete-plus.minimumWordLength',
+      (newValue) => this.minimumWordLength = newValue
+    )
   }
 
   getSchemaNames(editor, search) {
@@ -91,6 +95,7 @@ class SQLMetaProvider {
 
       let lastIdentifier = (identsLength > 1) && identifiers[identsLength - 2];
       let search = identifiers[identsLength - 1];
+      if (search.length < this.minimumWordLength) return [];
       results = this.getColumnNames(editor, search, lastIdentifier).concat(this.getTableNames(editor, search, lastIdentifier));
       if (!lastIdentifier)
         results = results.concat(this.getSchemaNames(editor, search));


### PR DESCRIPTION
This should fix #160, and shouldn't conflict with #166. 
Heads up, locally I'm unable to run / debug the tests: 
```
> apm test
Tests failed
```
so I'm PRing this unchecked to see if they work on Travis.